### PR TITLE
Version 1.0.4 - Bugfix

### DIFF
--- a/MackieUniversal.js
+++ b/MackieUniversal.js
@@ -35,6 +35,7 @@
         viewsArray[7] = "user";
     var storedColors = [7, 7, 7, 7, 7, 7, 7, 7];
     var timeWarningSent = false;
+    var forceUpdateClock = false;
 
 function init()
 {
@@ -138,6 +139,7 @@ function update(deltaTime)
         for(i=0;i<8;i++){
             local.sendChannelPressure(1,15+(16*i));
         }
+        forceUpdateClock = true;
     }
 }
 
@@ -577,13 +579,13 @@ function pitchWheelEvent(channel,value){
     //Is Master fader?
 
     if(channel==9){
-        local.values.main.mainFader.set(value/16383);
+        local.values.main.mainFader.set(value/16380);
         //local.sendPitchWheel(channel,value);
     }
     //It's a strip fader
     else{
         //Update strip module with new value
-        local.values.strips.getChild('Strip '+channel).faderValue.set(value/16383);
+        local.values.strips.getChild('Strip '+channel).faderValue.set(value/16380);
     }
 }
 
@@ -619,27 +621,28 @@ function updateClock()
     }
 
 
-    if (hours != newHours) {
+    if (hours != newHours || forceUpdateClock) {
         hours = newHours;
         local.sendCC(1, 71, 48+Math.floor(Math.floor(hours%10)));
         local.sendCC(1, 72, 48+Math.floor(Math.floor(hours/10)));
     }
 
-    if (minutes != newMinutes) {
+    if (minutes != newMinutes || forceUpdateClock) {
         minutes = newMinutes;
         local.sendCC(1, 69, 48+Math.round(Math.floor(minutes%10)));
         local.sendCC(1, 70, 48+Math.round(Math.floor(minutes/10)));
     }
 
-    if (seconds != newSeconds) {
+    if (seconds != newSeconds || forceUpdateClock) {
         seconds = newSeconds;
         local.sendCC(1, 67, 48+Math.round(Math.floor(seconds%10)));
         local.sendCC(1, 68, 48+Math.round(Math.floor(seconds/10)));
     }
     
-    if (partSeconds != newPartSeconds) {
+    if (partSeconds != newPartSeconds || forceUpdateClock) {
         partSeconds = newPartSeconds;
         local.sendCC(1, 65, 48+Math.floor((partSeconds%100)/10));
         local.sendCC(1, 66, 48+Math.floor(partSeconds/100));
     }
+    forceUpdateClock = false;
 }

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Mackie-Universal-Chataigne-Module
-A Chataigne module for Mackie protocole compatible MIDI Controllers
+A Chataigne module for the X-Touch Series and other Mackie protocol compatible MIDI Controllers
 WIP
 
 Changelog 
 1.0.4
 Bug Fix
-- Make sure clock is updated consistantly (force draw every second and a half)
+- Make sure clock is updated consistantly (force draw every 1.5 seconds)
 - Force faders to go all the way from 0 to 1, instead of .999
 
 1.0.3

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ A Chataigne module for Mackie protocole compatible MIDI Controllers
 WIP
 
 Changelog 
+1.0.4
+Bug Fix
+- Make sure clock is updated consistantly (force draw every second and a half)
+- Force faders to go all the way from 0 to 1, instead of .999
+
 1.0.3
 Bug Fixes
 - Encoder Assign lights fix Enum parameter

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
 	"type":"MIDI",
 	"path":"Hardware",
 	
-	"version":"1.0.3",
+	"version":"1.0.4",
 	"description":"Special MIDI Module for Mackie compatible controlers",
 	"url":"https://github.com/Guesn/Mackie-Control-Chataigne-Module",
 	"downloadURL":"https://github.com/Guesn/Mackie-Control-Chataigne-Module/archive/refs/heads/main.zip",


### PR DESCRIPTION
1.0.4
Bug Fix
- Make sure clock is updated consistantly (force draw every 1.5 seconds)
- Force faders to go all the way from 0 to 1, instead of .999